### PR TITLE
Upgrade terraform-provider-datarobot to v0.2.1

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -3,7 +3,7 @@ module github.com/datarobot-community/pulumi-datarobot/provider
 go 1.23
 
 require (
-	github.com/datarobot-community/terraform-provider-datarobot v0.2.0
+	github.com/datarobot-community/terraform-provider-datarobot v0.2.1
 	github.com/pulumi/pulumi-terraform-bridge/pf v0.44.1
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.91.1
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -340,8 +340,8 @@ github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81/go.mod h1:Yyn
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
-github.com/datarobot-community/terraform-provider-datarobot v0.2.0 h1:CMcpzhrZb5Xal6b9cJ1GV4mPgmCKHpJrPJqjYshvV44=
-github.com/datarobot-community/terraform-provider-datarobot v0.2.0/go.mod h1:xaWk+zZWomo5KxmIjTTmCnT8sFm1JjbFI5L+psSxuXs=
+github.com/datarobot-community/terraform-provider-datarobot v0.2.1 h1:yNU1uMsIw3TPoP/rHzaWr7ncviBjR4GIsV+3tzK0udk=
+github.com/datarobot-community/terraform-provider-datarobot v0.2.1/go.mod h1:xaWk+zZWomo5KxmIjTTmCnT8sFm1JjbFI5L+psSxuXs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider datarobot-community/pulumi-datarobot --upstream-provider-name terraform-provider-datarobot`.

---

- Upgrading terraform-provider-datarobot from 0.2.0  to 0.2.1.
