### PR TITLE
Upgrade terraform-provider-datarobot to v0.2.7

### DIFF
--- a/provider/cmd/pulumi-resource-datarobot/schema.json
+++ b/provider/cmd/pulumi-resource-datarobot/schema.json
@@ -1376,6 +1376,7 @@
                 "baseEnvironmentId",
                 "baseEnvironmentVersionId",
                 "deploymentsCount",
+                "description",
                 "filesHashes",
                 "folderPathHash",
                 "isProxy",

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -3,7 +3,7 @@ module github.com/datarobot-community/pulumi-datarobot/provider
 go 1.23
 
 require (
-	github.com/datarobot-community/terraform-provider-datarobot v0.2.6
+	github.com/datarobot-community/terraform-provider-datarobot v0.2.7
 	github.com/pulumi/pulumi-terraform-bridge/pf v0.45.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.92.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -340,8 +340,8 @@ github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81/go.mod h1:Yyn
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
-github.com/datarobot-community/terraform-provider-datarobot v0.2.6 h1:ed/Xq3vbXVOOfsJoD3hZtEWrw437dp752YgFy3c7fkg=
-github.com/datarobot-community/terraform-provider-datarobot v0.2.6/go.mod h1:xaWk+zZWomo5KxmIjTTmCnT8sFm1JjbFI5L+psSxuXs=
+github.com/datarobot-community/terraform-provider-datarobot v0.2.7 h1:NFuQfMBBVYfka+ohuXxLmv8XYLbeK86IRLReboctgec=
+github.com/datarobot-community/terraform-provider-datarobot v0.2.7/go.mod h1:xaWk+zZWomo5KxmIjTTmCnT8sFm1JjbFI5L+psSxuXs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/sdk/dotnet/CustomModel.cs
+++ b/sdk/dotnet/CustomModel.cs
@@ -123,7 +123,7 @@ namespace DataRobotPulumi.Datarobot
         /// The description of the Custom Model.
         /// </summary>
         [Output("description")]
-        public Output<string?> Description { get; private set; } = null!;
+        public Output<string> Description { get; private set; } = null!;
 
         /// <summary>
         /// The list of tuples, where values in each tuple are the local filesystem path and the path the file should be placed in the Custom Model. If list is of strings, then basenames will be used for tuples.

--- a/sdk/go/datarobot/customModel.go
+++ b/sdk/go/datarobot/customModel.go
@@ -68,7 +68,7 @@ type CustomModel struct {
 	// The number of deployments for the Custom Model.
 	DeploymentsCount pulumi.IntOutput `pulumi:"deploymentsCount"`
 	// The description of the Custom Model.
-	Description pulumi.StringPtrOutput `pulumi:"description"`
+	Description pulumi.StringOutput `pulumi:"description"`
 	// The list of tuples, where values in each tuple are the local filesystem path and the path the file should be placed in the Custom Model. If list is of strings, then basenames will be used for tuples.
 	Files pulumi.AnyOutput `pulumi:"files"`
 	// The hash of file contents for each file in files.
@@ -494,8 +494,8 @@ func (o CustomModelOutput) DeploymentsCount() pulumi.IntOutput {
 }
 
 // The description of the Custom Model.
-func (o CustomModelOutput) Description() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *CustomModel) pulumi.StringPtrOutput { return v.Description }).(pulumi.StringPtrOutput)
+func (o CustomModelOutput) Description() pulumi.StringOutput {
+	return o.ApplyT(func(v *CustomModel) pulumi.StringOutput { return v.Description }).(pulumi.StringOutput)
 }
 
 // The list of tuples, where values in each tuple are the local filesystem path and the path the file should be placed in the Custom Model. If list is of strings, then basenames will be used for tuples.

--- a/sdk/nodejs/customModel.ts
+++ b/sdk/nodejs/customModel.ts
@@ -120,7 +120,7 @@ export class CustomModel extends pulumi.CustomResource {
     /**
      * The description of the Custom Model.
      */
-    public readonly description!: pulumi.Output<string | undefined>;
+    public readonly description!: pulumi.Output<string>;
     /**
      * The list of tuples, where values in each tuple are the local filesystem path and the path the file should be placed in the Custom Model. If list is of strings, then basenames will be used for tuples.
      */

--- a/sdk/python/pulumi_datarobot/custom_model.py
+++ b/sdk/python/pulumi_datarobot/custom_model.py
@@ -1317,7 +1317,7 @@ class CustomModel(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def description(self) -> pulumi.Output[Optional[str]]:
+    def description(self) -> pulumi.Output[str]:
         """
         The description of the Custom Model.
         """


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider datarobot-community/pulumi-datarobot --upstream-provider-name terraform-provider-datarobot`.

---

- Upgrading terraform-provider-datarobot from 0.2.6  to 0.2.7.
