### PR TITLE
match sdk/python README with main README

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -63,3 +63,49 @@ The following configuration points are available for the DataRobot provider:
 ## Examples
 
 See [datarobot-pulumi examples](https://github.com/datarobot-community/pulumi-datarobot/tree/main/examples)
+
+## Air-Gapped Environments
+
+Keep the following items in mind if running in an air-gapped environment:
+
+- Run `pulumi login --local` to store state files on your local filesystem, instead of the default Pulumi Cloud. Pulumi binaries are available [here](https://www.pulumi.com/docs/iac/download-install/).
+- Set `DATAROBOT_ENDPOINT`: https://{datarobot.example.com}/api/v2
+    (replacing {datarobot.example.com} with your specific deployment endpoint)
+- For Python, the [pulumi](https://pypi.org/project/pulumi/) and [pulumi-datarobot](https://pypi.org/project/pulumi-datarobot/) packages must be installed in the air-gapped system. 
+
+    Example using `pip wheel`:
+
+    1. create a directory where you want to store package wheels.
+
+    ```bash
+    mkdir folder_containing_wheel
+    ```
+
+    2. Now install wheels of the python library you want to install
+
+    ```bash
+    pip wheel pulumi-datarobot -w folder_containing_wheel
+    ```
+
+    This will store all your required dependent wheels of the `pulumi-datarobot` package in the folder. you can check it with doing ls -ltr`.
+
+    3. Now, you can make a tar file of this folder.
+
+    ```bash
+    tar cf folder_containing_wheel.tar folder_containing_wheel/
+    ```
+
+    and you can transfer it to your air-gapped system.
+
+    Now untar the folder.
+
+    ```bash
+    tar xf folder_containing_wheel.tar
+    cd folder_containing_wheel/
+    ```
+
+    now install wheels from the folder.
+
+    ```bash
+    pip install * -f ./ --no-index 
+    ```


### PR DESCRIPTION
sdk/python README and main README need to match, in order to fix release error.