### PR TITLE
Upgrade terraform-provider-datarobot to v0.3.4

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -3,7 +3,7 @@ module github.com/datarobot-community/pulumi-datarobot/provider
 go 1.23
 
 require (
-	github.com/datarobot-community/terraform-provider-datarobot v0.3.3
+	github.com/datarobot-community/terraform-provider-datarobot v0.3.4
 	github.com/pulumi/pulumi-terraform-bridge/pf v0.46.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.93.1
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -338,8 +338,8 @@ github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81/go.mod h1:Yyn
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
-github.com/datarobot-community/terraform-provider-datarobot v0.3.3 h1:yFjcYcTQoJPOG8zjgSxxOc7PX0fh6HpMStmG4fyDPJM=
-github.com/datarobot-community/terraform-provider-datarobot v0.3.3/go.mod h1:xaWk+zZWomo5KxmIjTTmCnT8sFm1JjbFI5L+psSxuXs=
+github.com/datarobot-community/terraform-provider-datarobot v0.3.4 h1:XoXtvEG8zH4zCmxV5q2oyeAAkc5Z4a5nipigNZ4GmMo=
+github.com/datarobot-community/terraform-provider-datarobot v0.3.4/go.mod h1:mnVqufFKbGEoY6If2X9K9hhIVk0lEkFuMNYIJCFVOdI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider datarobot-community/pulumi-datarobot --upstream-provider-name terraform-provider-datarobot`.

---

- Upgrading terraform-provider-datarobot from 0.3.3  to 0.3.4.
