### PR TITLE
Upgrade terraform-provider-datarobot to v0.8.19

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -3,7 +3,7 @@ module github.com/datarobot-community/pulumi-datarobot/provider
 go 1.24.1
 
 require (
-	github.com/datarobot-community/terraform-provider-datarobot v0.8.18
+	github.com/datarobot-community/terraform-provider-datarobot v0.8.19
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.105.0
 )
 

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -325,8 +325,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.3.6 h1:4d9N5ykBnSp5Xn2JkhocYDkOpURL/18CYMpo6xB9uWM=
 github.com/cyphar/filepath-securejoin v0.3.6/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
-github.com/datarobot-community/terraform-provider-datarobot v0.8.18 h1:YvN4nIBwWeiiEY+gBXBcYkD9KpnCe6pM9bO06CRNJ/Y=
-github.com/datarobot-community/terraform-provider-datarobot v0.8.18/go.mod h1:lcu36FpyvixQbNYyOUc2tLwidixchhYCytQom2wLiYw=
+github.com/datarobot-community/terraform-provider-datarobot v0.8.19 h1:Uvmj+uJpkjJjHTuyewgHj97bVVPi0rYVSJHPiYJGgCM=
+github.com/datarobot-community/terraform-provider-datarobot v0.8.19/go.mod h1:lcu36FpyvixQbNYyOUc2tLwidixchhYCytQom2wLiYw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider datarobot-community/pulumi-datarobot --upstream-provider-name terraform-provider-datarobot`.

---

- Upgrading terraform-provider-datarobot from 0.8.18  to 0.8.19.
