### PR TITLE
Add release provider documentation for versioning and tagging process

### DIFF
--- a/.github/agents/release-provider.agent.md
+++ b/.github/agents/release-provider.agent.md
@@ -1,0 +1,39 @@
+---
+description: "Release provider: bump version, create git tag, and trigger release workflow. Use when asked to release, tag, bump version, or publish a new provider version."
+tools: [execute, read, search, mcp_gitkraken_git_status, mcp_gitkraken_git_log_or_diff, mcp_gitkraken_git_push, mcp_gitkraken_git_branch]
+---
+You are a release engineer for the pulumi-datarobot provider. Your job is to create a new semver release tag from the latest `main` branch and push it to trigger the Release workflow.
+
+## Release Process
+
+1. **Ensure clean state**: Check `git status` to confirm working tree is clean and you are on `main` with latest changes pulled.
+2. **Get current version**: Run `git describe --tags --abbrev=0` to find the latest semver tag (e.g., `v0.10.28`).
+3. **Check upstream terraform provider version**: Fetch the latest release tag from `https://api.github.com/repos/datarobot-community/terraform-provider-datarobot/releases/latest` using curl. The pulumi provider version should match or exceed the upstream terraform provider version.
+4. **Determine next version**:
+   - If the upstream terraform provider version is ahead, adopt that version.
+   - Otherwise, increment the patch version (e.g., `v0.10.28` → `v0.10.29`).
+   - If the user provides an explicit version, use that instead.
+5. **Show the plan**: Display the current version, upstream version, and proposed next version. Ask the user to confirm before proceeding.
+6. **Create and push the tag**:
+   ```
+   git tag -a <version> -m "Release <version>"
+   git push origin <version>
+   ```
+7. **Confirm**: Tell the user the tag was pushed and that the [Release workflow](.github/workflows/release.yml) will be triggered automatically by the `v*.*.*` tag pattern.
+
+## Constraints
+
+- NEVER force-push or delete existing tags
+- NEVER tag anything other than `main` branch HEAD unless explicitly asked
+- NEVER skip user confirmation before pushing the tag
+- ALWAYS verify the working tree is clean before tagging
+- ALWAYS pull latest `main` before tagging to avoid tagging stale commits
+- If an upgrade-provider PR is open and not yet merged, warn the user that they may want to merge it first
+
+## Version Logic
+
+The version follows the upstream terraform-provider-datarobot. The upgrade-provider workflow (`upgrade-provider.yml`) determines the version during upgrades using this logic:
+- If upstream terraform provider tag is ahead → adopt upstream version
+- Otherwise → increment patch of current version
+
+Apply the same logic when releasing manually.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
 
       - name: Validate PyPI token
         if: ${{ env.PUBLISH_PYPI == 'true' }}
@@ -53,41 +55,41 @@ jobs:
             echo "::error::PYPI_PASSWORD secret is not set"
             exit 1
           fi
-          
+
           # Check token format
           if [[ ! "$PYPI_TOKEN" =~ ^pypi- ]]; then
             echo "::error::PyPI token should start with 'pypi-'"
             exit 1
           fi
-          
+
           # Validate token by calling PyPI API
           pip install --quiet requests
           python3 << 'EOF'
           import os
           import requests
           import sys
-          
+
           token = os.environ.get('PYPI_TOKEN')
-          
+
           # Use the PyPI simple API with token auth to validate
           # We check if we can access project info (requires valid token)
           response = requests.get(
               'https://pypi.org/simple/pulumi-datarobot/',
               headers={'Authorization': f'Bearer {token}'}
           )
-          
+
           # Also verify via the legacy upload endpoint (returns 405 but validates auth)
           test_response = requests.post(
               'https://upload.pypi.org/legacy/',
               auth=('__token__', token),
               data={'': ''}  # Empty form data
           )
-          
+
           # 400 = bad request (but auth worked), 401/403 = auth failed
           if test_response.status_code in [401, 403]:
               print(f"::error::PyPI token authentication failed (HTTP {test_response.status_code})")
               sys.exit(1)
-          
+
           print("✅ PyPI token validated successfully")
           EOF
 
@@ -103,7 +105,7 @@ jobs:
         run: |
           npm install -g npm@latest
           echo "NPM version: $(npm --version)"
-          
+
           # Verify npm version supports OIDC (11.5.1+)
           NPM_VERSION=$(npm --version)
           REQUIRED_VERSION="11.5.1"
@@ -111,17 +113,17 @@ jobs:
             echo "::error::npm version $NPM_VERSION is less than required $REQUIRED_VERSION for OIDC trusted publishing"
             exit 1
           fi
-          
+
           # Check that the package exists on npm (we can publish updates)
           PACKAGE_NAME="${{ env.PACKAGE_NPM }}"
           HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/${PACKAGE_NAME}")
-          
+
           if [ "$HTTP_STATUS" != "200" ]; then
             echo "::warning::Package ${PACKAGE_NAME} not found on npm (HTTP $HTTP_STATUS). This might be a first publish."
           else
             echo "✅ Package ${PACKAGE_NAME} exists on npm registry"
           fi
-          
+
           echo "✅ NPM OIDC capability validated (version $NPM_VERSION >= $REQUIRED_VERSION)"
           echo "::notice::NPM publish will use OIDC trusted publishing - ensure trusted publisher is configured on npmjs.com"
 
@@ -135,38 +137,38 @@ jobs:
             echo "::error::NUGET_PUBLISH_KEY secret is not set"
             exit 1
           fi
-          
+
           # Check key length (NuGet API keys are typically 46+ characters)
           if [ ${#NUGET_API_KEY} -lt 40 ]; then
             echo "::error::NUGET_PUBLISH_KEY appears to be invalid (too short, expected 40+ characters)"
             exit 1
           fi
-          
+
           # Validate NuGet API key by calling the API
           # The verify-api-key endpoint validates the key without publishing
           HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" \
             -H "X-NuGet-ApiKey: $NUGET_API_KEY" \
             "https://api.nuget.org/v3/index.json")
-          
+
           HTTP_STATUS=$(echo "$HTTP_RESPONSE" | tail -n1)
-          
+
           # Check if we can access the API (200 = success)
           if [ "$HTTP_STATUS" != "200" ]; then
             echo "::warning::Could not verify NuGet API connectivity (HTTP $HTTP_STATUS)"
           fi
-          
+
           # Try to verify key by attempting to get package versions (requires auth for push)
           VERIFY_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
             -H "X-NuGet-ApiKey: $NUGET_API_KEY" \
             -X PUT \
             "https://www.nuget.org/api/v2/package/verify" 2>/dev/null || echo "000")
-          
+
           # 400 = bad request (but key format valid), 401/403 = invalid key
           if [ "$VERIFY_RESPONSE" = "401" ] || [ "$VERIFY_RESPONSE" = "403" ]; then
             echo "::error::NuGet API key authentication failed"
             exit 1
           fi
-          
+
           echo "✅ NuGet API key validated successfully"
 
       - name: Validate GitHub token permissions
@@ -178,24 +180,24 @@ jobs:
             -H "Authorization: token $GH_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ github.repository }}")
-          
+
           HTTP_STATUS=$(echo "$REPO_RESPONSE" | tail -n1)
-          
+
           if [ "$HTTP_STATUS" != "200" ]; then
             echo "::error::GITHUB_TOKEN cannot access repository (HTTP $HTTP_STATUS)"
             exit 1
           fi
-          
+
           # Check token permissions
           PERMISSIONS=$(curl -s \
             -H "Authorization: token $GH_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ github.repository }}" | jq -r '.permissions // empty')
-          
+
           if [ -n "$PERMISSIONS" ]; then
             echo "Token permissions: $PERMISSIONS"
           fi
-          
+
           echo "✅ GitHub token validated successfully"
 
       - name: Validation Summary
@@ -224,9 +226,11 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        fetch-depth: 0
 
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
+    - name: Fetch tags
+      run: git fetch --prune --tags --force
 
     - name: Install Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -257,8 +261,10 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
+        with:
+          fetch-depth: 0
+      - name: Fetch tags
+        run: git fetch --prune --tags --force
       - name: Install Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue
<!-- Link to the issue this PR addresses (if applicable) -->
Fixes #

## Type of Change
<!-- Mark relevant options with [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Provider upgrade (upstream terraform-provider-datarobot update)

## Checklist
<!-- Mark completed items with [x] -->
- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding style
- [ ] I have run `make lint_provider` and fixed any issues
- [ ] I have run `make test` and all tests pass
- [ ] I have updated documentation if needed
- [ ] My changes generate no new warnings

## Testing Done
<!-- Describe how you tested your changes -->

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Any additional information reviewers should know -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the GitHub Actions release workflow; incorrect tag fetching/history depth could break version detection and publishing even though changes are straightforward.
> 
> **Overview**
> Adds a new `.github/agents/release-provider.agent.md` runbook for manually cutting releases, including semver selection rules aligned with the upstream Terraform provider and safeguards (clean `main`, confirmation before tagging).
> 
> Updates `.github/workflows/release.yml` to always checkout with full history (`fetch-depth: 0`) and explicitly fetch tags in publish jobs, replacing the prior unshallow step to make tag-based versioning more reliable during releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f949382796ca3c4080cc709b12ebf537c3d9c22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->