### PR TITLE
Enhance PR detection logic in upgrade provider workflow with retries …

### DIFF
--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -88,22 +88,39 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         echo "Detecting upgrade provider PR branch (post action)..."
-        # Narrow search: open PRs authored by github-actions[bot] containing 'Upgrade provider'
-        PR_JSON=$(gh pr list --state open --author github-actions[bot] --search "Upgrade terraform-provider-datarobot" --json number,headRefName,title,updatedAt --limit 20 | jq -r 'sort_by(.updatedAt) | reverse | .[0]')
-        if [[ -z "$PR_JSON" || "$PR_JSON" == "null" ]]; then
-          echo "No matching upgrade provider PR found."
-          echo "pr_branch=" >> $GITHUB_OUTPUT
+
+        # First, try to detect from git state — the action may have left us on the created branch
+        CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+        DEFAULT_BRANCH=$(git remote show origin | awk '/HEAD branch/ {print $NF}')
+        if [[ -n "$CURRENT_BRANCH" && "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" && "$CURRENT_BRANCH" != "HEAD" ]]; then
+          echo "Detected current branch: $CURRENT_BRANCH (using as PR branch)"
+          echo "pr_branch=$CURRENT_BRANCH" >> $GITHUB_OUTPUT
           exit 0
         fi
-        PR_BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
-        PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
-        echo "Found PR: $PR_TITLE (branch: $PR_BRANCH)"
-        echo "pr_branch=$PR_BRANCH" >> $GITHUB_OUTPUT
+
+        # Fall back to searching via GitHub API with retries to handle propagation delay
+        for ATTEMPT in 1 2 3 4 5; do
+          echo "Attempt $ATTEMPT: searching for upgrade provider PR..."
+          PR_JSON=$(gh pr list --state open --author github-actions[bot] --search "Upgrade terraform-provider-datarobot" --json number,headRefName,title,updatedAt --limit 20 | jq -r 'sort_by(.updatedAt) | reverse | .[0]')
+          if [[ -n "$PR_JSON" && "$PR_JSON" != "null" ]]; then
+            PR_BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
+            PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+            echo "Found PR: $PR_TITLE (branch: $PR_BRANCH)"
+            echo "pr_branch=$PR_BRANCH" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "No PR found yet, waiting 15 s before retry..."
+          sleep 15
+        done
+
+        echo "No matching upgrade provider PR found after retries."
+        echo "pr_branch=" >> $GITHUB_OUTPUT
 
   generate_readmes:
     name: generate-readmes
     runs-on: ubuntu-latest
     needs: upgrade_provider
+    if: needs.upgrade_provider.outputs.pr_branch != ''
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
…and fallback

## Description
<!-- Describe your changes in detail -->

## Related Issue
<!-- Link to the issue this PR addresses (if applicable) -->
Fixes #

## Type of Change
<!-- Mark relevant options with [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Provider upgrade (upstream terraform-provider-datarobot update)

## Checklist
<!-- Mark completed items with [x] -->
- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding style
- [ ] I have run `make lint_provider` and fixed any issues
- [ ] I have run `make test` and all tests pass
- [ ] I have updated documentation if needed
- [ ] My changes generate no new warnings

## Testing Done
<!-- Describe how you tested your changes -->

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Any additional information reviewers should know -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; main impact is CI behavior where PR branch detection may wait/retry or skip downstream steps if no PR is found.
> 
> **Overview**
> Improves the `upgrade-provider.yml` workflow’s ability to find the PR branch created by the upgrade action by first using the current git branch (when it’s not the default branch) and otherwise retrying `gh pr list` up to 5 times with a delay to handle GitHub propagation.
> 
> Also gates the `generate_readmes` job behind a non-empty `pr_branch` output so README generation/checkout is skipped when no upgrade PR branch can be detected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b190e9f0e7c1499c9216beff23f45a8b029a460b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->