### PR TITLE
[-] Upgrade Go version to 1.26 across workflows and modules

### DIFF
--- a/.github/workflows/release-select.yml
+++ b/.github/workflows/release-select.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6.4.0
         with:
-          go-version: 1.24.x
+          go-version: 1.26.x
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v3.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.24.x
+        - 1.26.x
 
     steps:
     - name: Checkout Repo
@@ -324,7 +324,7 @@ jobs:
         dotnetversion:
           - 3.1.301
         goversion:
-          - 1.24
+          - 1.26
         language:
           - nodejs
           - python

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,8 +1,8 @@
 module github.com/datarobot-community/pulumi-datarobot/examples
 
-go 1.24.0
+go 1.26.4
 
-toolchain go1.24.1
+toolchain go1.26.4
 
 require github.com/pulumi/pulumi/pkg/v3 v3.160.0
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -2,8 +2,6 @@ module github.com/datarobot-community/pulumi-datarobot/examples
 
 go 1.26.4
 
-toolchain go1.26.4
-
 require github.com/pulumi/pulumi/pkg/v3 v3.160.0
 
 require (

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -1,6 +1,8 @@
 module github.com/datarobot-community/pulumi-datarobot/provider
 
-go 1.24.1
+go 1.26.4
+
+toolchain go1.26.4
 
 require (
 	github.com/datarobot-community/terraform-provider-datarobot v0.10.39

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,8 +1,8 @@
 module github.com/datarobot-community/pulumi-datarobot/sdk
 
-go 1.24.0
+go 1.26.4
 
-toolchain go1.24.1
+toolchain go1.26.4
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This pull request updates the Go version used throughout the project from 1.24 to 1.26 to ensure compatibility with the latest language features and tooling. The changes affect workflow configuration files and `go.mod` files in multiple modules.

**Build and Dependency Updates:**

* Updated the Go version in the `.github/workflows/release.yml` and `.github/workflows/release-select.yml` workflow files to use `1.26.x` instead of `1.24.x` for all relevant jobs and matrices. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L224-R224) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L327-R327) [[3]](diffhunk://#diff-8eb51b4cc84f7369600b936e857ebd7ca7a1e4ed535f5bd6b17a6168927eb33cL57-R57)
* Updated the `go.mod` and `toolchain` versions to `go 1.26.4` in the `examples`, `provider`, and `sdk` modules to match the new Go version requirement. [[1]](diffhunk://#diff-cd249c062d77b4d6a5621756423850d0708ffbe4aae554ce33cdc5b908b0ee39L3-R5) [[2]](diffhunk://#diff-0301265a2d4321ca487bbd7ba523f69633171cef680c0114e7ca8d2c34176b73L3-R5) [[3]](diffhunk://#diff-7b5028b779639efd98a7f47865b168ca39285e1c46d94140c5d38c516d00b127L3-R5)
## Related Issue
<!-- Link to the issue this PR addresses (if applicable) -->
Fixes #

## Type of Change
<!-- Mark relevant options with [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Provider upgrade (upstream terraform-provider-datarobot update)

## Checklist
<!-- Mark completed items with [x] -->
- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding style
- [ ] I have run `make lint_provider` and fixed any issues
- [ ] I have run `make test` and all tests pass
- [ ] I have updated documentation if needed
- [ ] My changes generate no new warnings

## Testing Done
<!-- Describe how you tested your changes -->

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Any additional information reviewers should know -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release and provider builds depend on Go 1.26 availability; contributors need 1.26+ or matching toolchain directives, but there is no application logic change.
> 
> **Overview**
> Bumps the repo’s **Go toolchain from 1.24 to 1.26.4** so local builds, CI, and release pipelines use the same compiler version.
> 
> **CI:** `release-select.yml` and `release.yml` now install Go **1.26.x** / **1.26** for binary publish and SDK matrix jobs (replacing **1.24.x** / **1.24**).
> 
> **Modules:** `provider/go.mod`, `sdk/go.mod`, and `examples/go.mod` set `go 1.26.4` and `toolchain go1.26.4` where applicable (provider previously had only `go 1.24.1` without an explicit toolchain line).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fcc19c73f4f98e1a248ce8a2788931923804376. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->