### PR TITLE
Bump Node.js to 22 in release workflows for npm publish

### DIFF
--- a/.github/workflows/release-select.yml
+++ b/.github/workflows/release-select.yml
@@ -107,7 +107,7 @@ jobs:
         if: ${{ github.event.inputs.SDK_LANGUAGE == 'nodejs' && env.PUBLISH_NPM == 'true' }}
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Ensure npm 11.5.1 or later

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
         if: ${{ env.PUBLISH_NPM == 'true' }}
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: 20
+          node-version: 22
           registry-url: ${{ env.NPM_REGISTRY_URL }}
 
       - name: Validate NPM OIDC and trusted publisher
@@ -331,7 +331,7 @@ jobs:
           - dotnet
           - go
         nodeversion:
-          - 20
+          - 22
         pythonversion:
           - "3.10"
 


### PR DESCRIPTION
## Summary
- `npm install -g npm@latest` now requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`, which Node 20 no longer satisfies, causing release/publish jobs to fail with `EBADENGINE` (see [failed run](https://github.com/datarobot-community/pulumi-datarobot/actions/runs/29482167685/job/87568200319)).
- Bump `node-version`/`nodeversion` from `20` to `22` for the npm-publish-related steps in `release.yml` and `release-select.yml`.

## Test plan
- [ ] Trigger a release (or release-select) run and confirm the "Setup Node" / npm upgrade steps succeed and `npm --version` is >= 11.5.1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Node version bumps for release automation; no application runtime or SDK source changes.
> 
> **Overview**
> Release and release-select GitHub Actions workflows now use **Node 22** instead of **Node 20** wherever npm is installed or validated.
> 
> This unblocks `npm install -g npm@latest` (npm 11.5.1+ for OIDC trusted publishing), which no longer supports Node 20 and was failing publish jobs with `EBADENGINE`. Updates cover the NPM credential validation step in `release.yml`, the publish SDK matrix `nodeversion`, and the Node.js setup step in `release-select.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36639f3da82d1b5eb650c01d5db4ac195196ac44. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->