### PR TITLE
Fix release workflow Go toolchain mismatch

### DIFF
--- a/.github/workflows/release-select.yml
+++ b/.github/workflows/release-select.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6.5.0
         with:
-          go-version: 1.26.x
+          go-version-file: provider/go.mod
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v3.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,11 +217,6 @@ jobs:
     name: publish
     runs-on: ubuntu-latest
     needs: validate_credentials
-    strategy:
-      fail-fast: true
-      matrix:
-        goversion:
-        - 1.26.x
 
     steps:
     - name: Checkout Repo
@@ -235,7 +230,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
-        go-version: ${{matrix.goversion}}
+        go-version-file: provider/go.mod
 
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@25e24d2d23ae098373794ef1d6faecb48ee52da8
@@ -268,7 +263,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version-file: provider/go.mod
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@25e24d2d23ae098373794ef1d6faecb48ee52da8 # v3.0.0
         with:
@@ -323,8 +318,6 @@ jobs:
       matrix:
         dotnetversion:
           - 3.1.301
-        goversion:
-          - 1.26
         language:
           - nodejs
           - python


### PR DESCRIPTION
## Summary
- The v0.10.43 release run failed at `make tfgen` inside GoReleaser with `go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)` (https://github.com/datarobot-community/pulumi-datarobot/actions/runs/29484830402/job/87576779647).
- Root cause: `release.yml` (`publish_binary`, `publish_sdk`) and `release-select.yml` pinned Go with a floating `go-version: 1.26.x` pattern instead of reading `provider/go.mod`. `setup-go` resolved that pattern to a patch older than what `go.mod` (bumped to `go 1.26.5` by the upgrade-provider bot in #335) actually requires, and since an explicit `go-version` makes `setup-go` set `GOTOOLCHAIN=local`, Go refused to auto-download the newer toolchain.
- Switched all three "Install Go" steps to `go-version-file: provider/go.mod`, matching the pattern `build.yml` already uses, so the installed toolchain always tracks whatever the bump bot last wrote — this removes the whole class of failure going forward, not just today's version mismatch.

## Test plan
- [x] YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] No remaining references to the removed `matrix.goversion`
- [ ] Next tag push (or a manual `workflow_dispatch` run of `release-select.yml`) completes `make tfgen` without a Go toolchain mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow edits with no application or publishing logic changes beyond installing the correct Go version.
> 
> **Overview**
> Fixes release failures where **GoReleaser** / `make tfgen` aborted because CI installed an older patch from a floating `1.26.x` pin while `provider/go.mod` required a newer minimum (with `GOTOOLCHAIN=local` blocking auto-upgrade).
> 
> **`release.yml`** and **`release-select.yml`** now use `go-version-file: provider/go.mod` on every Install Go step, matching **`build.yml`**. The redundant **`matrix.goversion`** entries and the **`publish_binary`** Go version matrix are removed so the toolchain tracks bot bumps in `go.mod` automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e381320a8017c43dfd0d05bee6ae76df1a765f77. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->