### PR TITLE
[APP-6684] Fix Python SDK config _utilities import broken by bridge codegen

### DIFF
--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -1,0 +1,32 @@
+---
+name: Review Router
+
+# SECURITY: This workflow intentionally uses pull_request_target (not
+# pull_request) because review-router never checks out or executes PR code.
+# Do NOT add actions/checkout or shell run: blocks here.
+#
+# If you need to build or test PR code, use a separate workflow with the
+# pull_request trigger instead.
+#
+# See: https://github.com/datarobot-oss/review-router/blob/main/docs/security/pull-request-target.md
+
+on:
+  pull_request_target:
+    types: [labeled, opened, closed, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: "0 3,9,15,21 * * 1-5"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  route:
+    uses: datarobot-community/.github/.github/workflows/review-router.yml@main
+    secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,8 @@ build_nodejs:: install_plugins tfgen # build the node sdk
 
 build_python:: install_plugins tfgen # build the python sdk
 	$(WORKING_DIR)/bin/$(TFGEN) python --overlays provider/overlays/python --out sdk/python/
+	@# Fix relative imports in subdirectory files — bridge generates ./ instead of ../ for subdir files
+	@sed -i.bak 's|^from \. import _utilities|from .. import _utilities|g' sdk/python/pulumi_datarobot/config/vars.py && rm -f sdk/python/pulumi_datarobot/config/vars.py.bak
 	@echo "Restoring Python-specific README..."
 	@sed -e "s/{{VERSION}}/$(VERSION)/g" \
 		-e "s|{{PACKAGE_NAME}}|pulumi-datarobot|g" \

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ build_nodejs:: install_plugins tfgen # build the node sdk
 build_python:: install_plugins tfgen # build the python sdk
 	$(WORKING_DIR)/bin/$(TFGEN) python --overlays provider/overlays/python --out sdk/python/
 	@# Fix relative imports in subdirectory files — bridge generates ./ instead of ../ for subdir files
-	@sed -i.bak 's|^from \. import _utilities|from .. import _utilities|g' sdk/python/pulumi_datarobot/config/vars.py && rm -f sdk/python/pulumi_datarobot/config/vars.py.bak
+	@sed -i.bak 's|^from \. import _utilities|from .. import _utilities|g' sdk/python/pulumi_datarobot/config/*.py sdk/python/pulumi_datarobot/config/*.pyi && rm -f sdk/python/pulumi_datarobot/config/*.bak
 	@echo "Restoring Python-specific README..."
 	@sed -e "s/{{VERSION}}/$(VERSION)/g" \
 		-e "s|{{PACKAGE_NAME}}|pulumi-datarobot|g" \

--- a/sdk/python/pulumi_datarobot/config/__init__.pyi
+++ b/sdk/python/pulumi_datarobot/config/__init__.pyi
@@ -13,7 +13,7 @@ if sys.version_info >= (3, 11):
     from typing import NotRequired, TypedDict, TypeAlias
 else:
     from typing_extensions import NotRequired, TypedDict, TypeAlias
-from . import _utilities
+from .. import _utilities
 
 apikey: Optional[str]
 """

--- a/sdk/python/pulumi_datarobot/config/vars.py
+++ b/sdk/python/pulumi_datarobot/config/vars.py
@@ -13,7 +13,7 @@ if sys.version_info >= (3, 11):
     from typing import NotRequired, TypedDict, TypeAlias
 else:
     from typing_extensions import NotRequired, TypedDict, TypeAlias
-from . import _utilities
+from .. import _utilities
 
 import types
 


### PR DESCRIPTION
## Description

Since the Go 1.26 bump the Terraform Bridge Python codegen emits `from . import _utilities` in config/vars.py, but _utilities.py lives at the package root, so pulumi_datarobot.config is unimportable and any `pulumi up` that touches it crashes. This broke pulumi-datarobot 0.10.41 through 0.10.43.

The Node.js build already patches the same "./ vs ../" bridge bug after generation; add the equivalent post-generation fixup to build_python so future regenerations stay correct, and correct the already-committed config/vars.py.

Fixes #

## Type of Change
<!-- Mark relevant options with [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Provider upgrade (upstream terraform-provider-datarobot update)

## Checklist
<!-- Mark completed items with [x] -->
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's coding style
- [x] I have run `make lint_provider` and fixed any issues
- [x] I have run `make test` and all tests pass
- [x] I have updated documentation if needed
- [ ] My changes generate no new warnings

## Testing Done
<!-- Describe how you tested your changes -->

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Any additional information reviewers should know -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small build-time and generated-SDK import fix with no auth or runtime provider logic changes.
> 
> **Overview**
> Fixes a **broken Python SDK import** where Terraform Bridge codegen wrote `from . import _utilities` in `pulumi_datarobot/config/vars.py` even though `_utilities` lives at the package root, which made `pulumi_datarobot.config` fail to import and could break `pulumi up` for affected releases.
> 
> The PR **updates the generated file** to `from .. import _utilities` and adds a **`build_python` post-generation `sed` step** (same pattern as the existing Node.js SDK fix) so future regenerations keep the correct relative import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e9b8b8b6d8c353d238b6ea2f365029b33debd26. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->