### PR TITLE
Group Dependabot security updates and cover all alerting manifests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,10 +54,12 @@ updates:
           - "minor"
           - "patch"
 
+  # Only the parent directory is listed: the pip file fetcher also collects
+  # requirements files from immediate subdirectories, so it already covers
+  # examples/py/deployment_grading/requirements.txt. Listing that path as well
+  # would create a second update job opening duplicate PRs for the same file.
   - package-ecosystem: "pip"
-    directories:
-      - "/examples/py"
-      - "/examples/py/deployment_grading"
+    directory: "/examples/py"
     schedule:
       interval: "weekly"
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,91 @@
 # See GitHub's documentation for more information on this file:
-# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot-yml-file
+#
+# Each ecosystem below declares two groups:
+#   * a `security-updates` group, so Dependabot bundles the fixes it opens in
+#     response to Dependabot alerts into a single PR instead of one PR per
+#     advisory. These are driven by alerts, not by `schedule`, and they ignore
+#     `open-pull-requests-limit`.
+#   * a `version-updates` group for routine minor/patch bumps. Majors are left
+#     out on purpose so they arrive as individual, reviewable PRs.
+#
+# The generated SDKs (sdk/nodejs, sdk/python, sdk/dotnet, sdk/java) are
+# deliberately absent: their manifests are codegen output that `make build_sdks`
+# rewrites, so dependency PRs against them would not survive regeneration.
 version: 2
 updates:
+  # The provider, the generated Go SDK and the examples all vendor the Pulumi
+  # and Terraform toolchains, and all three show up in Dependabot alerts.
   - package-ecosystem: "gomod"
-    directory: "/provider/"
+    directories:
+      - "/provider"
+      - "/sdk"
+      - "/examples"
     schedule:
       interval: "weekly"
-    groups: 
-      github-actions:
-        dependency-type: "production"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      gomod-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      gomod-minor-patch:
+        applies-to: version-updates
         update-types:
-        - "minor"
-        - "patch"
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/examples/ts"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "pip"
+    directories:
+      - "/examples/py"
+      - "/examples/py/deployment_grading"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    groups:
+      pip-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      pip-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    groups: 
-      github-actions:
-        dependency-type: "production"
+    labels:
+      - "dependencies"
+    groups:
+      github-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      github-actions-minor-patch:
+        applies-to: version-updates
         update-types:
-        - "minor"
-        - "patch"
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Why

Dependabot **alerts** are already enabled here, but Dependabot **security updates** (the setting that actually opens fix PRs) is off. Current open alerts:

| Severity | Count |
|---|---|
| Critical | 16 |
| High | 37 |
| Medium | 44 |
| Low | 3 |

The 16 criticals are `golang.org/x/crypto` (`sdk/go.mod`, `examples/go.mod`) and `protobufjs` / `tar` (`examples/ts/package-lock.json`).

The old config watched only `gomod` in `/provider` plus `github-actions`, and had no `applies-to` groups. Turning security updates on against that config would have produced a flood of single-advisory PRs, and nothing at all in the grouping for `sdk/`, `examples/go.mod`, `examples/ts` or `examples/py`.

## What changed

- A `security-updates` group per ecosystem (`patterns: ["*"]`), so alert-driven fixes arrive as **one grouped PR per ecosystem** instead of one per advisory.
- A `version-updates` group for routine minor/patch bumps; majors stay as individual PRs so they get reviewed on their own.
- Coverage extended to every manifest that currently has alerts: `gomod` in `/provider`, `/sdk`, `/examples`; `npm` in `/examples/ts`; `pip` in `/examples/py` and `/examples/py/deployment_grading`.
- Generated SDKs (`sdk/nodejs`, `sdk/python`, `sdk/dotnet`, `sdk/java`) deliberately excluded — `make build_sdks` rewrites those manifests, so dependency PRs against them would not survive regeneration.

## Follow-up after merge

Security updates need to be switched on at the repo level once this config is on `main`:

```
gh api -X PUT repos/datarobot-community/pulumi-datarobot/automated-security-fixes
```

(equivalently: Settings → Code security → Dependabot security updates). Doing it in this order is what keeps the first batch of fixes grouped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9b36d3edd271bb2b4523f5be87f9e151fc2b5cb9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->