### PR TITLE
[RAPTOR 18776] Parallel workload replacement doc

### DIFF
--- a/examples/py/workload_replacement/README.md
+++ b/examples/py/workload_replacement/README.md
@@ -5,21 +5,23 @@ Pulumi port of `terraform-provider-datarobot`'s
 
 ## How it triggers a replacement
 
-One `Artifact` (`app`) feeding one `Workload` (`api`), defined in
-[`__main__.py`](__main__.py):
+Two independent `Artifact`/`Workload` pairs — (`app-1`, `api-1`) and
+(`app-2`, `api-2`) — defined in [`__main__.py`](__main__.py), so you can
+trigger and observe replacement on each one separately (or both at once):
 
-- `app`'s `image_uri` is driven by the `containerImage` Pulumi config value
-  (defaults to `containous/whoami:latest`).
+- Each artifact's `image_uri` is driven by its own Pulumi config value
+  (`containerImage1` / `containerImage2`, both default to
+  `containous/whoami:latest`).
 - Artifacts default to `status="locked"`, so any spec change — changing
-  `containerImage` — makes Pulumi create a **new artifact version with a new
-  `artifact_id`** on the next `pulumi up`, instead of updating in place.
-- `api.artifact_id` is wired to `app.artifact_id`. Per the `Workload` schema,
-  changing `artifact_id` forces an **in-place replacement** of the workload
-  (`workload_id` and `workload_endpoint` stay stable — only the running
-  version behind them changes).
-
-So the whole demo is: change `containerImage`, re-apply, watch `api` get
-replaced.
+  either `containerImage1`/`containerImage2` — makes Pulumi create a **new
+  artifact version with a new `artifact_id`** on the next `pulumi up`,
+  instead of updating in place.
+- Each workload's `artifact_id` is wired to its own artifact's
+  `artifact_id`. Per the `Workload` schema, changing `artifact_id` forces an
+  **in-place replacement** of that workload (`workload_id` /
+  `workload_endpoint` stay stable — only the running version behind them
+  changes). The two pairs are independent: changing `containerImage1` only
+  replaces `api-1`, and vice versa.
 
 Uses the public `containous/whoami:latest` image via `image_uri` directly —
 no `source`/`image_build_config`, so there's no server-side image build step.
@@ -39,40 +41,52 @@ pulumi config set datarobot:apikey <your-api-token> --secret
 
 ## Run it
 
-**1. First deploy** — creates `app` (Artifact) and `api` (Workload built from
-`app`), serving `containous/whoami:latest`:
+**1. First deploy** — creates both pairs: `app-1`/`api-1` and `app-2`/`api-2`,
+each serving `containous/whoami:latest`:
 
 ```bash
 pulumi up
 ```
 
-**2. Trigger the replacement** — change the image and re-apply in one go:
+**2. Trigger replacement on one, both, or each independently:**
 
 ```bash
-pulumi config set containerImage containous/whoami:v1.5.0 && pulumi up
+# Replace only workload 1
+pulumi config set containerImage1 containous/whoami:v1.5.0 && pulumi up
+
+# Replace only workload 2
+pulumi config set containerImage2 containous/whoami:v1.5.0 && pulumi up
+
+# Replace both at once
+pulumi config set containerImage1 containous/whoami:v1.5.0
+pulumi config set containerImage2 containous/whoami:v1.5.0
+pulumi up
 ```
 
-`pulumi up` will show:
+`pulumi up` will show, for whichever pair(s) you changed:
 
 ```text
-+-  datarobot:index:Artifact  app   replace     # actually a new version, `app` itself is created fresh
- ~  datarobot:index:Workload  api   update      # artifact_id changed -> triggers in-place replacement
++-  datarobot:index:Artifact  app-1   replace     # actually a new version, `app-1` itself is created fresh
+ ~  datarobot:index:Workload  api-1   update      # artifact_id changed -> triggers in-place replacement
 ```
 
-(`app` is a brand-new `Artifact` resource version under the hood since it's
-`locked`; `api` keeps its identity — `workload_id`/`workload_endpoint` don't
-change — while the provider swaps the running version behind it.)
+(`app-N` is a brand-new `Artifact` resource version under the hood since
+it's `locked`; `api-N` keeps its identity — `workload_N_id`/
+`workload_N_endpoint` don't change — while the provider swaps the running
+version behind it.)
 
 **3. Verify:**
 
 ```bash
-pulumi stack output artifact_version_id   # should differ from before step 2
-curl "$(pulumi stack output workload_endpoint)"
+pulumi stack output artifact_1_version_id   # should differ from before step 2
+pulumi stack output artifact_2_version_id
+curl "$(pulumi stack output workload_1_endpoint)"
+curl "$(pulumi stack output workload_2_endpoint)"
 ```
 
 `whoami` doesn't print a version label — confirm the swap via
-`artifact_version_id` changing, or by comparing the `Hostname`/container id
-in the curl response before and after.
+`artifact_1_version_id`/`artifact_2_version_id` changing, or by comparing
+the `Hostname`/container id in the curl responses before and after.
 
 ## Tear down
 

--- a/examples/py/workload_replacement/__main__.py
+++ b/examples/py/workload_replacement/__main__.py
@@ -1,58 +1,76 @@
 import pulumi
 import pulumi_datarobot as dr
 
-# Mirrors terraform-provider-datarobot's
-# examples/workflows/workload_replacement/main.tf: ONE Artifact resource whose
-# spec is driven by config. Artifacts default to status="locked", so any spec
-# change (here: `container_image`) produces a NEW artifact version/artifact_id
-# on `pulumi up` — which is what triggers the Workload's in-place replacement.
+# Two independent Artifact/Workload pairs so you can trigger — and observe —
+# in-place replacement on each one separately (or both at once).
+#
+# Artifacts default to status="locked", so any spec change (here:
+# containerImage1 / containerImage2) produces a NEW artifact version /
+# artifact_id on `pulumi up` — which is what triggers each Workload's
+# in-place replacement.
 
 config = pulumi.Config()
 workload_name = config.get("workloadName") or "workload-replacement-example"
-# Change this (pulumi config set containerImage <image>) and re-apply to
-# trigger an in-place workload replacement.
-container_image = config.get("containerImage") or "containous/whoami:latest"
 replica_count = config.get_int("replicaCount") or 2
 
-app = dr.Artifact(
-    "app",
-    name=f"{workload_name}-artifact",
-    type="service",
-    spec=dr.ArtifactSpecArgs(
-        container_groups=[
-            dr.ArtifactSpecContainerGroupArgs(
-                containers=[
-                    dr.ArtifactSpecContainerGroupContainerArgs(
-                        name="main",
-                        image_uri=container_image,
-                        port=8080,
-                        primary=True,
-                        entrypoints=["/whoami", "--port", "8080"],
-                    ),
-                ],
-            ),
-        ],
-    ),
-)
+# Change either of these (pulumi config set containerImage1/2 <image>) and
+# re-apply to trigger that pair's in-place workload replacement.
+container_image_1 = config.get("containerImage1") or "containous/whoami:latest"
+container_image_2 = config.get("containerImage2") or "containous/whoami:latest"
 
-api = dr.Workload(
-    "api",
-    name=workload_name,
-    description="Workload replacement workflow example",
-    artifact_id=app.artifact_id,
-    # replacement_policy (warmup_minutes / keep_old_version_minutes) is
-    # omitted: the locally installed pulumi_datarobot build predates that
-    # field (see README "Known local SDK gap"). Platform defaults apply.
-    runtime=dr.WorkloadRuntimeArgs(
-        container_groups=[
-            dr.WorkloadRuntimeContainerGroupArgs(
-                replica_count=replica_count,
-                resource_bundles=["cpu.small"],
-            ),
-        ],
-    ),
-)
 
-pulumi.export("workload_id", api.id)
-pulumi.export("workload_endpoint", api.endpoint)
-pulumi.export("artifact_version_id", app.artifact_id)
+def make_pair(suffix: str, container_image: str) -> tuple[dr.Artifact, dr.Workload]:
+    name = f"{workload_name}-{suffix}"
+
+    artifact = dr.Artifact(
+        f"app-{suffix}",
+        name=f"{name}-artifact",
+        type="service",
+        spec=dr.ArtifactSpecArgs(
+            container_groups=[
+                dr.ArtifactSpecContainerGroupArgs(
+                    containers=[
+                        dr.ArtifactSpecContainerGroupContainerArgs(
+                            name="main",
+                            image_uri=container_image,
+                            port=8080,
+                            primary=True,
+                            entrypoints=["/whoami", "--port", "8080"],
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    )
+
+    workload = dr.Workload(
+        f"api-{suffix}",
+        name=name,
+        description=f"Workload replacement workflow example ({suffix})",
+        artifact_id=artifact.artifact_id,
+        # replacement_policy (warmup_minutes / keep_old_version_minutes) is
+        # omitted: the locally installed pulumi_datarobot build predates that
+        # field (see README "Known local SDK gap"). Platform defaults apply.
+        runtime=dr.WorkloadRuntimeArgs(
+            container_groups=[
+                dr.WorkloadRuntimeContainerGroupArgs(
+                    replica_count=replica_count,
+                    resource_bundles=["cpu.small"],
+                ),
+            ],
+        ),
+    )
+
+    return artifact, workload
+
+
+artifact_1, api_1 = make_pair("1", container_image_1)
+artifact_2, api_2 = make_pair("2", container_image_2)
+
+pulumi.export("workload_1_id", api_1.id)
+pulumi.export("workload_1_endpoint", api_1.endpoint)
+pulumi.export("artifact_1_version_id", artifact_1.artifact_id)
+
+pulumi.export("workload_2_id", api_2.id)
+pulumi.export("workload_2_endpoint", api_2.endpoint)
+pulumi.export("artifact_2_version_id", artifact_2.artifact_id)


### PR DESCRIPTION
## Description
This PR serves on top of the previous workload-replacement doc, the doc for a parallel double workload-replacement, allowing user to experience the real waiting time for both, which stays low.

## Type of Change
<!-- Mark relevant options with [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Provider upgrade (upstream terraform-provider-datarobot update)

## Checklist
<!-- Mark completed items with [x] -->
- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding style
- [ ] I have run `make lint_provider` and fixed any issues
- [ ] I have run `make test` and all tests pass
- [ ] I have updated documentation if needed
- [ ] My changes generate no new warnings

## Testing Done
<!-- Describe how you tested your changes -->

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Any additional information reviewers should know -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example and documentation only; no provider or production code paths change.
> 
> **Overview**
> The **`examples/py/workload_replacement`** demo now provisions **two independent `Artifact`/`Workload` pairs** (`app-1`/`api-1` and `app-2`/`api-2`) instead of a single pair, so users can trigger and observe in-place replacement on one workload, the other, or both in one `pulumi up`.
> 
> Implementation is refactored via a **`make_pair`** helper; image tags come from **`containerImage1`** and **`containerImage2`** (replacing **`containerImage`**). Stack exports are split into **`workload_1_*` / `artifact_1_*`** and **`workload_2_*` / `artifact_2_*`**. The README documents per-pair and combined replacement flows and updated verification commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d7d2e65f673f99bafff82d0bc6d26cbaa67535c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->