### PR TITLE
Upgrade the Go toolchain to 1.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ Regenerating a section preserves that subsection.
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped the Go toolchain in all three modules' `go.mod` from `1.26.6` (`provider`,
+  `sdk`) and `1.26.4` (`examples`) to `1.27.1`, the current Go release. Not a security
+  bump: `govulncheck` reports the same findings before and after, with no standard
+  library advisories under either toolchain. All CI jobs resolve Go via
+  `go-version-file: provider/go.mod`, so this also raises the version used to build
+  releases. Toolchain-only change; `go mod tidy` produced no dependency changes and no
+  provider behavior changes.
+
 ## [0.11.1] - 2026-09-01
 
 ### Upstream provider changes

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/datarobot-community/pulumi-datarobot/examples
 
-go 1.26.4
+go 1.27.1
 
 require github.com/pulumi/pulumi/pkg/v3 v3.257.0
 

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -1,6 +1,6 @@
 module github.com/datarobot-community/pulumi-datarobot/provider
 
-go 1.26.6
+go 1.27.1
 
 require (
 	github.com/datarobot-community/terraform-provider-datarobot v0.11.1

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/datarobot-community/pulumi-datarobot/sdk
 
-go 1.26.6
+go 1.27.1
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
Bumps the `go` directive in all three modules to `1.27.1`, the current Go release: `provider` and `sdk` from `1.26.6`, `examples` from `1.26.4`.

All CI jobs resolve Go via `go-version-file: provider/go.mod`, so nothing else in the repo pins a toolchain version and this also raises the version used to build releases.

Not a security bump — `govulncheck` reports identical findings before and after, with no standard library advisories under either toolchain. The three findings it does report are all in dependencies and unaffected by this change: `GO-2026-6355` and `GO-2026-6354` in `golang.org/x/crypto@v0.55.0`, and `GO-2026-6258` in `go.opentelemetry.io/otel/bridge/opentracing@v1.33.0`.

### Verification

All run under `go1.27.1`:

- `go mod tidy` in all three modules — no dependency changes, only the `go` directive moved
- `go build ./...`, `go vet ./...`, `go test ./...` on `provider` — pass
- `go build ./...` on `sdk`, `go vet ./...` on `examples` — pass
- `golangci-lint run -c ../.golangci.yml` on `provider` — 0 issues
- `govulncheck ./...` on `provider` — compared against the pre-bump tree, same result

### Note for local development

golangci-lint refuses to run when it was built with an older Go than the target, so a local golangci-lint older than `v2.13.2` now fails `make lint` with:

```
can't load config: the Go language version (go1.26) used to build golangci-lint is lower than the targeted Go version (1.27.1)
```

Upgrade locally to `v2.13.2` (built with `go1.27.0`). CI is unaffected — `build.yml` pins `version: latest`, which resolves to `v2.13.2`; that exact binary is what produced the 0-issue lint run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Toolchain and changelog only; no module dependency or runtime provider logic changes.
> 
> **Overview**
> **Raises the Go toolchain to `1.27.1`** in `provider/go.mod`, `sdk/go.mod`, and `examples/go.mod` (from `1.26.6` on provider/sdk and `1.26.4` on examples). CI and release builds already read Go from `provider/go.mod` via `go-version-file`, so this also moves the compiler used for those jobs.
> 
> **Documents the bump** under `[Unreleased]` → **Changed** in `CHANGELOG.md`, noting it is toolchain-only: no dependency updates from `go mod tidy`, no provider behavior change, and `govulncheck` unchanged versus the prior toolchain.
> 
> **Local dev note (from PR context, not in the diff):** developers may need a newer `golangci-lint` (e.g. v2.13.2+) built with Go 1.27+ so `make lint` matches the new `go` directive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bae52273f999204dd49f0069090d67127657568. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->