### PR TITLE
release 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,18 +22,6 @@ Changes made in this repo rather than upstream go under `Unreleased` while unrel
 and under a `### Provider changes` subsection once they ship in a version.
 Regenerating a section preserves that subsection.
 
-## [Unreleased]
-
-### Changed
-
-- Bumped the Go toolchain in all three modules' `go.mod` from `1.26.6` (`provider`,
-  `sdk`) and `1.26.4` (`examples`) to `1.27.1`, the current Go release. Not a security
-  bump: `govulncheck` reports the same findings before and after, with no standard
-  library advisories under either toolchain. All CI jobs resolve Go via
-  `go-version-file: provider/go.mod`, so this also raises the version used to build
-  releases. Toolchain-only change; `go mod tidy` produced no dependency changes and no
-  provider behavior changes.
-
 ## [0.11.2] - 2026-09-08
 
 ### Upstream provider changes
@@ -49,6 +37,14 @@ Regenerating a section preserves that subsection.
 - `source.dir_hash` on `datarobot_artifact` plans as known after apply whenever the directory differs from state or the catalog moved, since the sync can add or remove files; the value recorded is the digest of the directory once the sync is done.
 
 ##### Changed
+
+- Bumped the Go toolchain in all three modules' `go.mod` from `1.26.6` (`provider`,
+  `sdk`) and `1.26.4` (`examples`) to `1.27.1`, the current Go release. Not a security
+  bump: `govulncheck` reports the same findings before and after, with no standard
+  library advisories under either toolchain. All CI jobs resolve Go via
+  `go-version-file: provider/go.mod`, so this also raises the version used to build
+  releases. Toolchain-only change; `go mod tidy` produced no dependency changes and no
+  provider behavior changes.
 
 - **`datarobot_artifact` apply now needs write access to `source.dir`.** The sync keeps its last-synced manifest there (`source.dir/.datarobot/workload/`), so a directory the provider cannot write to, such as a read-only checkout mounted into CI or a `0555` tree, fails the apply with `create sync state directory (source.dir must be writable ...)`. The push-only upload in earlier releases never wrote into the directory, so this can break an existing pipeline on upgrade with no configuration change: make the directory writable, or point `source.dir` at a writable copy.
 - **One `source.dir` per `datarobot_artifact` resource.** The sync state under a directory is bound to one catalog, so a second resource over a directory that already backs a live artifact from another artifact repository is refused with the cause (checked under the directory's sync lock, so a parallel apply cannot slip past it), and two resources racing for the same directory fail on its lock the same way. Give each resource its own directory. A destroyed and re-created resource, a locked artifact cloning to a new version, and a checkout whose directory last synced an older version of the same resource are not affected; two resources deliberately sharing one `artifact_repository_id` and one directory are not told apart from one resource's versions, so do not do that.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue
<!-- Link to the issue this PR addresses (if applicable) -->
Fixes #

## Type of Change
<!-- Mark relevant options with [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Provider upgrade (upstream terraform-provider-datarobot update)

## Checklist
<!-- Mark completed items with [x] -->
- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding style
- [ ] I have run `make lint_provider` and fixed any issues
- [ ] I have run `make test` and all tests pass
- [ ] I have updated documentation if needed
- [ ] My changes generate no new warnings

## Testing Done
<!-- Describe how you tested your changes -->

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Any additional information reviewers should know -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edit with no runtime or SDK surface impact.
> 
> **Overview**
> **Release notes housekeeping for v0.11.2.** The `Unreleased` section is removed and its **Changed** entry (Go **1.27.1** across `provider`, `sdk`, and `examples` `go.mod`, CI via `provider/go.mod`) is placed at the top of **Changed** under the existing **0.11.2** upstream block, alongside the already-documented upstream artifact sync and Go bump items.
> 
> No provider code, dependencies, or Pulumi schema changes appear in this diff—only `CHANGELOG.md` is touched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61e8def51ccf11e9b6a4806635904d8089c7d809. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->